### PR TITLE
Special char in URL

### DIFF
--- a/index.php
+++ b/index.php
@@ -603,7 +603,7 @@ do {
 	// SET REQUEST HEADERS
 	//
 	$_request_headers = '';
-	$_request_headers = $_request_method.' '.$_url_parts['path'];
+	$_request_headers = $_request_method.' '. urldecode( $_url_parts['path'] );
 
 	if (isset($_url_parts['query'])) {
 		$_request_headers .= '?';


### PR DESCRIPTION
Trying to fix issue with special char in URL such as Wikipedia (mentionned in https://github.com/AmauryCarrade/OranjeProxy/issues/14).

   * decode URL's path in request headers

While this seems to work with Wikipédia, further tests should be done to avoid regression.